### PR TITLE
added link to complete ADIwg manual

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,16 +10,16 @@
 
   <meta property="og:title" content="Alaska Region mdEditor Interim User Guide" />
   <meta property="og:type" content="book" />
-  
-  
+
+
   <meta property="og:description" content="INTERIM requirements and best practices for the creation of high-quality and consistent metadata records for projects and products from the Alaska Region (AK-Region) of the US Fish and Wildlife Service (USFWS)." />
-  
+
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="Alaska Region mdEditor Interim User Guide" />
-  
+
   <meta name="twitter:description" content="INTERIM requirements and best practices for the creation of high-quality and consistent metadata records for projects and products from the Alaska Region (AK-Region) of the US Fish and Wildlife Service (USFWS)." />
-  
+
 
 <meta name="author" content="Alaska Region Data Stewardship Team" />
 
@@ -28,8 +28,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-  
-  
+
+
 
 <link rel="next" href="projects-products-and-contacts.html"/>
 <script src="libs/jquery-2.2.3/jquery.min.js"></script>
@@ -304,7 +304,7 @@
 <h1>Introduction</h1>
 <div class="rmdcaution">
 <p>
-This is a working draft that will continue to be edited. Last updated: 2019-10-02. Please refresh this manual every time you open it to ensure you are viewing the most recent version.
+This is a working draft that will continue to be edited. Last updated: 2019-10-02. Please refresh this manual every time you open it to ensure you are viewing the most recent version. The <a href="https://adiwg.gitbooks.io/mdeditor/">official version</a> of the mdEditor manual is maintained by the Alaska Data Integration Working Group (<a href="https://github.com/adiwg">ADIwg</a>).
 </p>
 </div>
 <p>The Alaska Region of the U.S. Fish and Wildlife Service is committed to improving the management of its data resources. A comprehensive, long-term plan to develop and implement a Regional Data Management System (RDMS) will begin in the winter of 2019, with the expectation that it will be fully operational and in use in 3-5 years. In the interim, there is a strong desire in the Region to begin managing existing and new data resources with the systems available to staff now.</p>


### PR DESCRIPTION
The warning block at the top of the introduction has been modified to include a link to the complete mdEditor manual. This could help to avoid confusing this version with the official mdEditor documentation. See also issue #7.